### PR TITLE
Also send the GroupID to use in your device converter.

### DIFF
--- a/lib/shepherd.js
+++ b/lib/shepherd.js
@@ -131,7 +131,7 @@ function ZShepherd(path, opts) {
         notifData.cid = cIdString ? cIdString.key : cId;
         notifData.data = payload;
 
-        self.emit('ind', { type: type, endpoints: [ ep ], data: notifData, linkquality: msg.linkquality });
+        self.emit('ind', { type: type, endpoints: [ ep ], data: notifData, linkquality: msg.linkquality, groupid: msg.groupid });
     });
 
     this.on('ind:statusChange', function (ep, cId, payload, msg) {


### PR DESCRIPTION
https://github.com/Koenkk/zigbee2mqtt/issues/635

For example. a Trust ZYCT-202 has a choice selector. Every choice sends its own GroupID.
The groupid and generated actions can be processed again in a device converter.