### PR TITLE
Add Support SwannOne Key Fob SWO-KEF1PA

### DIFF
--- a/lib/components/af.js
+++ b/lib/components/af.js
@@ -691,7 +691,8 @@ function dispatchIncomingMsg(type, msg) {
             const cmdIDs = ['on', 'offWithEffect', 'step', 'stop', 'hueNotification', //Philips-RWL020-RWL021
                             'off', 'stepColorTemp', 'moveWithOnOff', 'move', 'moveHue', 'moveToSaturation', //OSRAM-Switch 4x EU-LIGHTIFY
                             'stopWithOnOff', 'moveToLevelWithOnOff', 'toggle', 'tradfriArrowSingle', 'tradfriArrowHold', 'tradfriArrowRelease',
-                            'stepWithOnOff', 'moveToColorTemp', 'moveToColor', 'onWithTimedOff', 'recall'];
+                            'stepWithOnOff', 'moveToColorTemp', 'moveToColor', 'onWithTimedOff', 'recall', 'arm', 'panic' //SwannOne Key Fob SWO-KEF1PA
+            ];
 
             if (frameType === 1 && cmdIDs.includes(msg.zclMsg.cmdId) && msg.zclMsg.payload) {
                 af.controller._shepherd.emit('ind:cmd', targetEp, msg.clusterid, msg.zclMsg.payload, msg.zclMsg.cmdId, msg);


### PR DESCRIPTION
Zcl 'panic' and 'armmode' are required so it registers properly in
zigbee2mqtt.

Related
https://github.com/Koenkk/zigbee2mqtt/pull/1256